### PR TITLE
Adding an option to disable creating keys when enabling hiera-eyaml and

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ Configures the directory for puppet's confdir.
 Configures the hiera logger. Default is 'console'
 #### `merge_behavior`
 Configures the hiera merge behavior (e.g. for deep merges). No default
+#### `create_keys`
+Enables/disables generating pkcs7 keys for use with hiera-eyaml
 #### `extra_config`
 Accepts arbitrary content to add to the end of hiera.yaml
 

--- a/manifests/eyaml.pp
+++ b/manifests/eyaml.pp
@@ -11,11 +11,12 @@
 # Copyright (C) 2014 Terri Haber, unless otherwise noted.
 #
 class hiera::eyaml (
-  $provider = $hiera::params::provider,
-  $owner    = $hiera::owner,
-  $group    = $hiera::group,
-  $cmdpath  = $hiera::cmdpath,
-  $confdir  = $hiera::confdir
+  $provider    = $hiera::params::provider,
+  $owner       = $hiera::owner,
+  $group       = $hiera::group,
+  $cmdpath     = $hiera::cmdpath,
+  $confdir     = $hiera::confdir,
+  $create_keys = $hiera::create_keys
 ) inherits hiera::params {
 
   package { 'hiera-eyaml':
@@ -23,36 +24,35 @@ class hiera::eyaml (
     provider => $provider,
   }
 
+  File {
+    owner => $owner,
+    group => $group
+  }
+
   file { "${confdir}/keys":
     ensure => directory,
-    owner  => $owner,
-    group  => $group,
-    before => Exec['createkeys'],
   }
 
-  exec { 'createkeys':
-    user    => $owner,
-    cwd     => $confdir,
-    command => 'eyaml createkeys',
-    path    => $cmdpath,
-    creates => "${confdir}/keys/private_key.pkcs7.pem",
-    require => Package['hiera-eyaml'],
-  }
+  if ( $create_keys == true ) {
+    exec { 'createkeys':
+      user    => $owner,
+      cwd     => $confdir,
+      command => 'eyaml createkeys',
+      path    => $cmdpath,
+      creates => "${confdir}/keys/private_key.pkcs7.pem",
+      require => [ Package['hiera-eyaml'], File["${confdir}/keys"] ]
+    }
 
+    file { "${confdir}/keys/private_key.pkcs7.pem":
+      ensure  => file,
+      mode    => '0600',
+      require => Exec['createkeys'],
+    }
 
-  file { "${confdir}/keys/private_key.pkcs7.pem":
-    ensure  => file,
-    mode    => '0600',
-    owner   => $owner,
-    group   => $group,
-    require => Exec['createkeys'],
-  }
-
-  file { "${confdir}/keys/public_key.pkcs7.pem":
-    ensure  => file,
-    mode    => '0644',
-    owner   => $owner,
-    group   => $group,
-    require => Exec['createkeys'],
+    file { "${confdir}/keys/public_key.pkcs7.pem":
+      ensure  => file,
+      mode    => '0644',
+      require => Exec['createkeys'],
+    }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -59,6 +59,11 @@
 #   Note: You need to manage any package/gem dependancies
 #   Default: native
 #
+# [*create_keys*]
+#   Enable or disable pkcs7 key generation and file management with hiera-eyaml
+#   This is helpful if you need to distribute a pkcs7 key pair
+#   Default: true
+#
 # [*cmdpath*]
 #   Search paths for command binaries, like the 'eyaml' command.
 #   The default should cover most cases.
@@ -110,6 +115,7 @@ class hiera (
   $confdir         = $hiera::params::confdir,
   $logger          = $hiera::params::logger,
   $cmdpath         = $hiera::params::cmdpath,
+  $create_keys     = $hiera::params::create_keys,
   $merge_behavior  = undef,
   $extra_config    = '',
 ) inherits hiera::params {
@@ -145,5 +151,5 @@ class hiera (
   file { '/etc/hiera.yaml':
     ensure => symlink,
     target => $hiera_yaml,
-  }  
+  }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -34,4 +34,5 @@ class hiera::params {
   $backends        = ['yaml']
   $logger          = 'console'
   $eyaml_extension = undef
+  $create_keys     = true
 }


### PR DESCRIPTION
managing the keys files. Adding a default owner and group for file
resources in eyaml.pp to reduce duplication.