### PR TITLE
Eyaml gpg

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,50 @@ The resulting output in /etc/puppet/hiera.yaml:
 :merge_behavior: deep
 ```
 
+**Configure with hirea-eyaml-gpg**
+```puppet
+class { 'hiera':
+  hierarchy => [
+    'nodes/%{::clientcert}',
+    'locations/%{::location}',
+    'environments/%{::applicationtier}',
+    'common',
+  ],
+  logger               => 'console',
+  eyaml                => true,
+  eyaml_gpg            => true,
+  eyaml_gpg_keygen     => true,
+  eyaml_gpg_recipients => 'sihil@example.com,gtmtech@example.com,tpoulton@example.com',
+}
+```
+
+The resulting output in /etc/puppet/hiera.yaml:
+```yaml
+---
+:backends:
+  - eyaml
+  - yaml
+:logger: console
+:hierarchy:
+  - "nodes/%{::clientcert}"
+  - "locations/%{::location}"
+  - "environments/%{::applicationtier}"
+  - common
+
+:yaml:
+   :datadir: /etc/puppet/hieradata
+
+
+:eyaml:
+   :datadir: /etc/puppet/hieradata
+   :pkcs7_private_key: /etc/puppet/keys/private_key.pkcs7.pem
+   :pkcs7_public_key:  /etc/puppet/keys/public_key.pkcs7.pem
+   :encrypt_method: "gpg"
+   :gpg_gnupghome: "/etc/puppet/keys/gpg"
+   :gpg_recipients: "sihil@example.com,gtmtech@example.com,tpoulton@example.com"
+```
+
+
 ### Classes
 
 #### Public Classes
@@ -106,6 +150,7 @@ The resulting output in /etc/puppet/hiera.yaml:
 #### Private Classes
 - hiera::params: Handles variable conditionals
 - hiera::eyaml: Handles eyaml configuration
+- hiera::eyaml_gpg: Handles eyaml-gpg plugin configuration
 
 ### Parameters
 
@@ -180,8 +225,15 @@ The following parameters are available for the hiera class:
   Arbitrary YAML content to append to the end of the hiera.yaml config file.  
   This is useful for configuring backend-specific parameters.  
   Default: `''`
-
-[eyaml]: https://github.com/TomPoulton/hiera-eyaml
+* `eyaml_gpg`
+  Enables/disable the eyaml-gpg backend. 
+  Default: `false`
+* `eyaml_gpg_keygen`
+  Generate a GPG Keyring. 
+  Default: `false` ( Currently only works for RedHat OS Family )
+* `eyaml_gpg_recipients`
+  Sets the gpg recipients list in hiera.yaml for hirea-eyaml-gpg
+  Default: `undef`
 
 ## Limitations
 

--- a/manifests/eyaml_gpg.pp
+++ b/manifests/eyaml_gpg.pp
@@ -1,0 +1,75 @@
+# == Class hiera::eyaml_gpg
+#
+# This calss install and configures hiera-eyaml-gpg
+#
+class hiera::eyaml_gpg (
+  $provider         = $hiera::params::provider,
+  $owner            = $hiera::owner,
+  $group            = $hiera::group,
+  $confdir          = $hiera::confdir,
+  $cmdpath          = $hiera::cmdpath,
+  $eyaml_gpg_keygen = $hiera::eyaml_gpg_keygen,
+) inherits hiera::params {
+
+  require hiera::eyaml
+
+  # Ruby Development Packages are required for for the gpgme gem
+  include ruby::dev
+
+  package { 'gpgme':
+    ensure   => installed,
+    provider => $provider,
+    before   => Package['hiera-eyaml-gpg'],
+    require  => Class['ruby::dev'],
+  }
+
+  package { 'hiera-eyaml-gpg':
+    ensure   => installed,
+    provider => $provider,
+  }
+
+  file { "${confdir}/keys/gpg":
+    ensure => directory,
+    owner  => $owner,
+    group  => $group,
+    mode   => '0700'
+  }
+
+  # Currently only works for RedHat based machines, until gnupg packages in params is updated
+  if $eyaml_gpg_keygen and $::osfamily == 'RedHat' {
+
+    file { "${confdir}/keys/gpg/gpg_answers":
+      ensure  => present,
+      owner   => $owner,
+      group   => $group,
+      mode    => '0700',
+      content => template('hiera/gpg_answers.erb'),
+      before  => Exec['gpg_genkeys'],
+    }
+
+    package { "${hiera::params::gnupg_package}":
+      ensure => installed,
+    }
+
+    exec { 'gpg_genkeys':
+      user    => $owner,
+      cwd     => $confdir,
+      path    => $cmdpath,
+      command => "gpg --batch --homedir ${confdir}/keys/gpg --gen-key ${confdir}/keys/gpg/gpg_answers",
+      creates => "${confdir}/keys/gpg/pubring.gpg",
+      require => Package["${hiera::params::gnupg_package}"],
+    }
+
+    $gpg_files = [ "${confdir}/keys/gpg/pubring.gpg", "${confdir}/keys/gpg/pibring.gpg~", "${confdir}/keys/gpg/random_seed", "${confdir}/keys/gpg/secring.gpg", "${confdir}/keys/gpg/trustdb.gpg" ]
+
+    file { $gpg_files:
+      ensure  => file,
+      mode    => '0600',
+      owner   => $owner,
+      group   => $group,
+      require => Exec['gpg_genkeys'],
+    }
+
+  }
+  
+}

--- a/manifests/eyaml_gpg.pp
+++ b/manifests/eyaml_gpg.pp
@@ -60,7 +60,7 @@ class hiera::eyaml_gpg (
       require => Package["${hiera::params::gnupg_package}"],
     }
 
-    $gpg_files = [ "${confdir}/keys/gpg/pubring.gpg", "${confdir}/keys/gpg/pibring.gpg~", "${confdir}/keys/gpg/random_seed", "${confdir}/keys/gpg/secring.gpg", "${confdir}/keys/gpg/trustdb.gpg" ]
+    $gpg_files = [ "${confdir}/keys/gpg/pubring.gpg", "${confdir}/keys/gpg/pubring.gpg~", "${confdir}/keys/gpg/random_seed", "${confdir}/keys/gpg/secring.gpg", "${confdir}/keys/gpg/trustdb.gpg" ]
 
     file { $gpg_files:
       ensure  => file,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,7 +57,11 @@ class hiera (
   $eyaml_version   = undef,
   $merge_behavior  = undef,
   $extra_config    = '',
+  $eyaml_gpg            = false,
+  $eyaml_gpg_keygen     = false,
+  $eyaml_gpg_recipients = $hiera::params::eyaml_gpg_recipients,
 ) inherits hiera::params {
+
   File {
     owner => $owner,
     group => $group,
@@ -73,7 +77,9 @@ class hiera (
       fail("${merge_behavior} merge behavior is invalid. Valid values are: native, deep, deeper")
     }
   }
-  if $eyaml {
+  if $eyaml_gpg {
+    require hiera::eyaml_gpg
+  } elsif $eyaml {
     require hiera::eyaml
   }
   # Template uses:

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -37,4 +37,14 @@ class hiera::params {
     $provider   = 'gem'
     $confdir    = '/etc/puppet'
   }
+  $cmdpath              = ['/opt/puppet/bin', '/usr/bin', '/usr/local/bin']
+  $datadir_manage       = true
+  $backends             = ['yaml']
+  $logger               = 'console'
+  $eyaml_extension      = undef
+  $eyaml_gpg_recipients = undef
+  
+  if $::osfamily == 'RedHat' {
+    $gnupg_package         = 'gnupg2'
+  }
 }

--- a/templates/gpg_answers.erb
+++ b/templates/gpg_answers.erb
@@ -1,0 +1,13 @@
+%echo Generating a Puppet Hiera GPG Key
+Key-Type: RSA
+Key-Length: 4096
+Subkey-Type: ELG-E
+Subkey-Length: 4096
+Name-Real: Hiera Data
+Name-Comment: Hiera Data Encryption
+Name-Email: puppet@<%= @domain %>
+Expire-Date: 0
+%no-ask-passphrase
+# Do a commit here, so that we can later print "done" :-)
+# %commit
+# %echo done

--- a/templates/hiera.yaml.erb
+++ b/templates/hiera.yaml.erb
@@ -21,7 +21,15 @@ end -%>
 <% end -%>
    :pkcs7_private_key: <%= @confdir %>/keys/private_key.pkcs7.pem
    :pkcs7_public_key:  <%= @confdir %>/keys/public_key.pkcs7.pem
-<% end %>
+<% end -%>
+<% if @eyaml_gpg -%>
+   :encrypt_method: "gpg"
+   :gpg_gnupghome: "/etc/puppet/keys/gpg"
+<% if @eyaml_gpg_recipients -%>
+   :gpg_recipients: "<%= @eyaml_gpg_recipients %>"
+<% end -%>
+<% end -%>
+   
 
 <% if @merge_behavior -%>
 :merge_behavior: <%= @merge_behavior -%>


### PR DESCRIPTION
Add the ability to install/configure hiera-eyaml-gpg. 
 * Configures needed hiera.yaml properties
 * Installs needed gems

Note:  Added puppetlabs/ruby dep as its the ruby-devel package is needed so it installs it

There is an oddity that if the pkcs7 keys for hiera-eyaml-gpg need created AND the hiera-eyaml-gpg gem is already installed it fails to create the keys and the run reports back failed.  To compensate for this I have a exec that will remove the hiera-eyaml-gpg ONLY if the pkcs7 keys have not been generated.  This lead to the potential for the hiera-eyaml-gpg gem to not be installed on a single run but will be install on the next puppet run.  I don't see this as being something that is run into often.


Example Usage

class { 'hiera':
  hierarchy => [
    'nodes/%{::clientcert}',
    'locations/%{::location}',
    'environments/%{::applicationtier}',
    'common',
  ],
  logger    => 'console',
  eyaml     => true,
  eyaml_gpg => true,
  eyaml_gpg_keygen => true,
  eyaml_gpg_recipients => 'sihil@example.com,gtmtech@example.com,tpoulton@example.com',
}