### PR TITLE
Fix 37 prov

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,8 +19,12 @@ class hiera::params {
     $datadir    = '/etc/puppetlabs/puppet/hieradata'
     $owner      = 'pe-puppet'
     $group      = 'pe-puppet'
-    $provider   = 'pe_gem'
     $confdir    = '/etc/puppetlabs/puppet'
+    if $::puppetversion =~ /3.7/ {
+      $provider = 'puppetserver'
+    } else {
+      $provider = 'pe_gem'
+    }
   } else {
     $hiera_yaml = '/etc/puppet/hiera.yaml'
     $datadir    = '/etc/puppet/hieradata'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,6 +22,11 @@ class hiera::params {
     $confdir    = '/etc/puppetlabs/puppet'
     if $::puppetversion =~ /3.7/ {
       $provider = 'pe_puppetserver_gem'
+      # 3.7 also needs /opt/puppet/bin/eyaml
+      exec { 'install pe_gem':
+          command => '/opt/puppet/bin/gem install hiera-eyaml'
+          creates => '/opt/puppet/bin/eyaml'
+      }
     } else {
       $provider = 'pe_gem'
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,8 +24,8 @@ class hiera::params {
       $provider = 'pe_puppetserver_gem'
       # 3.7 also needs /opt/puppet/bin/eyaml
       exec { 'install pe_gem':
-          command => '/opt/puppet/bin/gem install hiera-eyaml'
-          creates => '/opt/puppet/bin/eyaml'
+          command => '/opt/puppet/bin/gem install hiera-eyaml',
+          creates => '/opt/puppet/bin/eyaml',
       }
     } else {
       $provider = 'pe_gem'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,7 +21,7 @@ class hiera::params {
     $group      = 'pe-puppet'
     $confdir    = '/etc/puppetlabs/puppet'
     if $::puppetversion =~ /3.7/ {
-      $provider = 'puppetserver'
+      $provider = 'pe_puppetserver_gem'
     } else {
       $provider = 'pe_gem'
     }


### PR DESCRIPTION
This adds pe_puppetserver_gem to the provider for PE 3.7 in params, for hiera-eyaml installation. I do have a bit of a conundrum as a fresh install doesn't work until pe-puppetserver is restarted. BUT restarting pe-puppetserver in code could cause cascading failures for end users due to JVM startup time. Does anyone have thoughts on this? Should we just leave this out for now and just add documentation that JVM needs to be restarted? Or do we wait for things down the line that will fix this issue?