### PR TITLE
Install compatible version of HighLine on Ruby 1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 - Added ability to disable pkcs7 key generation with hiera-eyaml
 - Added `gem_source` param
 
+### Bugfixes:
+- Install compatible version of HighLine when installing hiera-eyaml on Ruby 1.8
+
 ## [1.1.1] - 2014-11-21
 ### Bugfixes:
 - Correct handling of `cmdpath` (using an array of paths instead of hardcoded

--- a/manifests/eyaml.pp
+++ b/manifests/eyaml.pp
@@ -5,10 +5,12 @@
 # === Authors:
 #
 # Terri Haber <terri@puppetlabs.com>
+# Eli Young <elyscape@gmail.com>
 #
 # === Copyright:
 #
 # Copyright (C) 2014 Terri Haber, unless otherwise noted.
+# Copyright (C) 2015 Eli Young, unless otherwise noted.
 #
 class hiera::eyaml (
   $provider    = $hiera::params::provider,
@@ -20,6 +22,14 @@ class hiera::eyaml (
   $gem_source  = $hiera::gem_source,
 ) inherits hiera::params {
 
+  if versioncmp($::rubyversion, '1.9.3') < 0 {
+    package { 'highline':
+      ensure   => '~> 1.6.19',
+      provider => provider,
+      source   => $gem_source,
+      before   => Package['hiera-eyaml'],
+    }
+  }
   package { 'hiera-eyaml':
     ensure   => installed,
     provider => $provider,


### PR DESCRIPTION
Recent versions of HighLine, a dependency for hiera-eyaml, are
incompatible with Ruby 1.8.

Fixes #53.