### PR TITLE
Terrimonster fix 37 prov

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this project will be documented in this file.
 ### Bugfixes:
 - Change Modulefile to metadata.json
 - Add validation on `merge_behavior` param
+- Make it kind of work on PE 3.7 (pe-puppetserver must still be restarted after
+  the gem is installed)
 
 ## [1.1.1] - 2014-11-21
 ### Bugfixes:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This module configures [Hiera](https://github.com/puppetlabs/hiera) for Puppet.
 - /etc/hiera.yaml for symlink
 
 ### Setup requirements
-If you are using Puppet Enterprise and the eyaml backend, you will need the [puppetlabs-pe_gem](https://forge.puppetlabs.com/puppetlabs/pe_gem) module to install the eyaml gem using PE's gem command.
+If you are using Puppet Enterprise and the eyaml backend, you will need the [puppetlabs-pe_gem](https://forge.puppetlabs.com/puppetlabs/pe_gem) module to install the eyaml gem using PE's gem command. If you are using a PE version with puppetserver (3.7 and later) you will also need the [puppetlabs-pe_puppetserver_gem](https://forge.puppetlabs.com/puppetlabs/pe_puppetserver_gem) module.
 
 Otherwise you just need puppet.
 
@@ -182,7 +182,7 @@ The following parameters are available for the hiera class:
 
 ## Limitations
 
-Unknown.
+The pe-puppetserver service must be restarted after hiera-eyaml is installed; this module will not do it for you.
 
 ## Development
 

--- a/manifests/eyaml.pp
+++ b/manifests/eyaml.pp
@@ -25,6 +25,22 @@ class hiera::eyaml (
     provider => $provider,
     source   => $gem_source,
   }
+  if $provider == 'pe_puppetserver_gem' {
+    # The puppetserver gem wouldn't install the commandline util, so we do
+    # that here
+    #XXX Pre-puppet 4.0.0 version (PUP-1073)
+    exec { 'install pe_gem':
+      command => '/opt/puppet/bin/gem install hiera-eyaml',
+      creates => '/opt/puppet/bin/eyaml',
+    }
+    #XXX Post-puppet 4.0.0
+    #package { 'hiera-eyaml command line':
+    #  ensure   => installed,
+    #  name     => 'hiera-eyaml',
+    #  provider => 'pe_gem',
+    #  source   => $gem_source,
+    #}
+  }
 
   File {
     owner => $owner,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,8 +19,12 @@ class hiera::params {
     $datadir    = '/etc/puppetlabs/puppet/hieradata'
     $owner      = 'pe-puppet'
     $group      = 'pe-puppet'
-    $provider   = 'pe_gem'
     $confdir    = '/etc/puppetlabs/puppet'
+    if $::puppetversion =~ /3.7/ {
+      $provider = 'puppetserver'
+    } else {
+      $provider = 'pe_gem'
+    }
   } else {
     $hiera_yaml = '/etc/puppet/hiera.yaml'
     $datadir    = '/etc/puppet/hieradata'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,6 +22,11 @@ class hiera::params {
     $confdir    = '/etc/puppetlabs/puppet'
     if $::puppetversion =~ /3.7/ {
       $provider = 'pe_puppetserver_gem'
+      # 3.7 also needs /opt/puppet/bin/eyaml
+      exec { 'install pe_gem':
+          command => '/opt/puppet/bin/gem install hiera-eyaml'
+          creates => '/opt/puppet/bin/eyaml'
+      }
     } else {
       $provider = 'pe_gem'
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,8 +24,8 @@ class hiera::params {
       $provider = 'pe_puppetserver_gem'
       # 3.7 also needs /opt/puppet/bin/eyaml
       exec { 'install pe_gem':
-          command => '/opt/puppet/bin/gem install hiera-eyaml'
-          creates => '/opt/puppet/bin/eyaml'
+          command => '/opt/puppet/bin/gem install hiera-eyaml',
+          creates => '/opt/puppet/bin/eyaml',
       }
     } else {
       $provider = 'pe_gem'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,7 +21,7 @@ class hiera::params {
     $group      = 'pe-puppet'
     $confdir    = '/etc/puppetlabs/puppet'
     if $::puppetversion =~ /3.7/ {
-      $provider = 'puppetserver'
+      $provider = 'pe_puppetserver_gem'
     } else {
       $provider = 'pe_gem'
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,11 +22,6 @@ class hiera::params {
     $confdir    = '/etc/puppetlabs/puppet'
     if $::puppetversion =~ /3.7/ {
       $provider = 'pe_puppetserver_gem'
-      # 3.7 also needs /opt/puppet/bin/eyaml
-      exec { 'install pe_gem':
-          command => '/opt/puppet/bin/gem install hiera-eyaml',
-          creates => '/opt/puppet/bin/eyaml',
-      }
     } else {
       $provider = 'pe_gem'
     }


### PR DESCRIPTION
Rebase and readme update for #45. We still need to solve the following issue:

> This adds pe_puppetserver_gem to the provider for PE 3.7 in params, for hiera-eyaml installation. I do have a bit of a conundrum as a fresh install doesn't work until pe-puppetserver is restarted. BUT restarting pe-puppetserver in code could cause cascading failures for end users due to JVM startup time. Does anyone have thoughts on this? Should we just leave this out for now and just add documentation that JVM needs to be restarted? Or do we wait for things down the line that will fix this issue?