### PR TITLE
Fix typo in backends parameter name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The following parameters are available for the hiera class:
 * `hierarchy`  
   The hiera hierarchy.  
   Default: `[]`
-* `backend`  
+* `backends`  
   The list of backends.  
   Default: `['yaml']`
 * `hiera_yaml`  


### PR DESCRIPTION
The README file has a typo where it lists the parameters to the main class.  It says "backend" but that should be plural.  This commit fixes it.