### PR TITLE
Support AIO Puppet 4

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,7 +51,7 @@ class hiera (
   $eyaml_extension = undef,
   $confdir         = $hiera::params::confdir,
   $logger          = 'console',
-  $cmdpath         = ['/opt/puppet/bin', '/usr/bin', '/usr/local/bin'],
+  $cmdpath         = $hiera::params::cmdpath,
   $create_keys     = true,
   $gem_source      = undef,
   $eyaml_version   = undef,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,6 +20,7 @@ class hiera::params {
     $owner      = 'pe-puppet'
     $group      = 'pe-puppet'
     $confdir    = '/etc/puppetlabs/puppet'
+    $cmdpath    = ['/opt/puppet/bin', '/usr/bin', '/usr/local/bin']
 
 
     if versioncmp($::pe_version, '3.7.0') >= 0 {
@@ -34,9 +35,11 @@ class hiera::params {
       # Configure for AIO packaging.
       $provider = 'puppet_gem'
       $confdir  = '/etc/puppetlabs/code'
+      $cmdpath  = ['/opt/puppetlabs/puppet/bin', '/usr/bin', '/usr/local/bin']
     } else {
       $provider = 'gem'
       $confdir  = '/etc/puppet'
+      $cmdpath  = ['/usr/bin', '/usr/local/bin']
     }
     $hiera_yaml = "${confdir}/hiera.yaml"
     $datadir    = "${confdir}/hieradata"

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -30,11 +30,17 @@ class hiera::params {
     }
   }
   else {
-    $hiera_yaml = '/etc/puppet/hiera.yaml'
-    $datadir    = '/etc/puppet/hieradata'
+    if versioncmp($::puppetversion, '4.0.0') >= 0 {
+      # Configure for AIO packaging.
+      $provider = 'puppet_gem'
+      $confdir  = '/etc/puppetlabs/code'
+    } else {
+      $provider = 'gem'
+      $confdir  = '/etc/puppet'
+    }
+    $hiera_yaml = "${confdir}/hiera.yaml"
+    $datadir    = "${confdir}/hieradata"
     $owner      = 'puppet'
     $group      = 'puppet'
-    $provider   = 'gem'
-    $confdir    = '/etc/puppet'
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppet",
-      "version_requirement": "3.x"
+      "version_requirement": ">= 3.0.0 < 5.0.0"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
This PR adds Puppet 4 AIO paths and providers to `params.pp`.