### PR TITLE
make 'eyaml_datair' same as 'datadir' by default

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,7 +14,7 @@
 #
 # === Requires:
 #
-# Nothing.
+# puppetlabs-stdlib >= 4.3.1
 #
 # === Sample Usage:
 #
@@ -47,7 +47,7 @@ class hiera (
   $owner           = $hiera::params::owner,
   $group           = $hiera::params::group,
   $eyaml           = false,
-  $eyaml_datadir   = $hiera::params::datadir,
+  $eyaml_datadir   = undef,
   $eyaml_extension = undef,
   $confdir         = $hiera::params::confdir,
   $logger          = 'console',
@@ -75,6 +75,10 @@ class hiera (
   }
   if $eyaml {
     require hiera::eyaml
+    $eyaml_real_datadir = empty($eyaml_datadir) ? {
+      false => $eyaml_datadir,
+      true  => $datadir,
+    }
   }
   # Template uses:
   # - $eyaml
@@ -82,7 +86,7 @@ class hiera (
   # - $logger
   # - $hierarchy
   # - $datadir
-  # - $eyaml_datadir
+  # - $eyaml_real_datadir
   # - $eyaml_extension
   # - $confdir
   # - $merge_behavior

--- a/metadata.json
+++ b/metadata.json
@@ -17,7 +17,10 @@
       "version_requirement": "3.x"
     }
   ],
-  "dependencies": [
-  
+ "dependencies": [
+    {
+      "name": "puppetlabs-stdlib",
+      "version_range": ">= 4.3.1"
+    }
   ]
 }

--- a/templates/hiera.yaml.erb
+++ b/templates/hiera.yaml.erb
@@ -13,15 +13,15 @@ end -%>
 :yaml:
    :datadir: <%= @datadir %>
 
-<% if @eyaml %>
+<% if @eyaml -%>
 :eyaml:
-   :datadir: <%= @eyaml_datadir %>
+   :datadir: <%= @eyaml_real_datadir %>
 <% if @eyaml_extension -%>
    :extension: <%= @eyaml_extension %>
 <% end -%>
    :pkcs7_private_key: <%= @confdir %>/keys/private_key.pkcs7.pem
    :pkcs7_public_key:  <%= @confdir %>/keys/public_key.pkcs7.pem
-<% end %>
+<% end -%>
 
 <% if @merge_behavior -%>
 :merge_behavior: <%= @merge_behavior -%>


### PR DESCRIPTION
It would match documentation, make redundant code unnecessary and solve #61 
also, since hiera::params is using str2bool function, module is dependent on stdlib