### PR TITLE
adding double quotes around eyaml_version to address Evaluation Error…

### DIFF
--- a/manifests/eyaml.pp
+++ b/manifests/eyaml.pp
@@ -35,7 +35,7 @@ class hiera::eyaml (
     # that here
     #XXX Pre-puppet 4.0.0 version (PUP-1073)
     #BUG This can't actually update the gem version if already installed.
-    if $eyaml_version =~ /^\d+\.\d+\.\d+$/ {
+    if "$eyaml_version" =~ /^\d+\.\d+\.\d+$/ {
       $gem_flag = "--version ${eyaml_version}"
     } else {
       $gem_flag = undef


### PR DESCRIPTION
…: Left match operand must result in a String value

By double quoting eyaml_version, the default 'undef' value is accepted.  I also tested with assigning eyaml_version a value and the module compiled.