### PR TITLE
Fix package provider on Puppet Enterprise 2015.x

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,3 +1,7 @@
 fixtures:
+  forge_modules:
+    stdlib:
+      repo: "puppetlabs-stdlib"
+      ref: "4.7.0"
   symlinks:
     "hiera": "#{source_dir}"

--- a/manifests/eyaml.pp
+++ b/manifests/eyaml.pp
@@ -25,11 +25,7 @@ class hiera::eyaml (
     undef   => 'installed',
     default => $eyaml_version,
   }
-  package { 'hiera-eyaml':
-    ensure   => $package_ensure,
-    provider => $provider,
-    source   => $gem_source,
-  }
+
   if $provider == 'pe_puppetserver_gem' {
     # The puppetserver gem wouldn't install the commandline util, so we do
     # that here
@@ -51,6 +47,12 @@ class hiera::eyaml (
     #  provider => 'pe_gem',
     #  source   => $gem_source,
     #}
+  } else {
+    package { 'hiera-eyaml':
+      ensure   => $package_ensure,
+      provider => $provider,
+      source   => $gem_source,
+    }
   }
 
   File {

--- a/manifests/eyaml.pp
+++ b/manifests/eyaml.pp
@@ -27,6 +27,8 @@ class hiera::eyaml (
   }
 
   if $provider == 'pe_puppetserver_gem' {
+    $hiera_package_dep = Exec['install pe_gem']
+
     # The puppetserver gem wouldn't install the commandline util, so we do
     # that here
     #XXX Pre-puppet 4.0.0 version (PUP-1073)
@@ -48,6 +50,7 @@ class hiera::eyaml (
     #  source   => $gem_source,
     #}
   } else {
+    $hiera_package_dep = Package['hiera-eyaml']
     package { 'hiera-eyaml':
       ensure   => $package_ensure,
       provider => $provider,
@@ -71,7 +74,7 @@ class hiera::eyaml (
       command => 'eyaml createkeys',
       path    => $cmdpath,
       creates => "${confdir}/keys/private_key.pkcs7.pem",
-      require => [ Package['hiera-eyaml'], File["${confdir}/keys"] ]
+      require => [ $hiera_package_dep, File["${confdir}/keys"] ]
     }
 
     file { "${confdir}/keys/private_key.pkcs7.pem":


### PR DESCRIPTION
Hi,

When running under Puppet Enterprise 3.8 instantiated with the following code:
```
  class { 'hiera':
    hierarchy => [
      'nodes/%{clientcert}',
      'app_tier/%{app_tier}',
      'env/%{environment}',
      'common',
    ],
    datadir   => $profiles::puppet::params::hieradir,
    backends  => $backends,
    eyaml     => true,
    notify    => Service['pe-puppetserver'],
  }
```
The following error will be displayed:
```
Error: Failed to apply catalog: Parameter provider failed on Package[hiera-eyaml]: Invalid package provider 'pe_puppetserver_gem' at /etc/puppetlabs/puppet/environments/production/modules/hiera/manifests/eyaml.pp:32
```

This PR fixes this by only attempting to use a package resource when the provider is not `pe_puppetserver_gem`.

RSpec tests are (fixed) and still passing