### PR TITLE
hiera-eyaml gem installation on PE 2015.2 (x2)

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,3 +1,7 @@
 fixtures:
+  forge_modules:
+    stdlib:
+      repo: "puppetlabs-stdlib"
+      ref: "4.7.0"
   symlinks:
     "hiera": "#{source_dir}"

--- a/manifests/eyaml.pp
+++ b/manifests/eyaml.pp
@@ -25,11 +25,7 @@ class hiera::eyaml (
     undef   => 'installed',
     default => $eyaml_version,
   }
-  package { 'hiera-eyaml':
-    ensure   => $package_ensure,
-    provider => $provider,
-    source   => $gem_source,
-  }
+
   if $provider == 'pe_puppetserver_gem' {
     # The puppetserver gem wouldn't install the commandline util, so we do
     # that here
@@ -51,6 +47,12 @@ class hiera::eyaml (
     #  provider => 'pe_gem',
     #  source   => $gem_source,
     #}
+  } else {
+    package { 'hiera-eyaml':
+      ensure   => $package_ensure,
+      provider => $provider,
+      source   => $gem_source,
+    }
   }
 
   File {

--- a/manifests/eyaml.pp
+++ b/manifests/eyaml.pp
@@ -29,8 +29,11 @@ class hiera::eyaml (
   if $provider == 'pe_puppetserver_gem' {
     Exec {
       path => [
+        '/opt/puppetlabs/server/bin/',
         '/opt/puppetlabs/puppet/bin',
         '/opt/puppet/bin',
+        '/usr/bin/',
+        '/bin',
       ]
     }
 

--- a/manifests/eyaml.pp
+++ b/manifests/eyaml.pp
@@ -34,7 +34,10 @@ class hiera::eyaml (
       ]
     }
 
-    $hiera_package_dep = Exec['install pe_gem']
+    $hiera_package_dep = [
+      Exec['install ruby gem hiera-eyaml'],
+      Exec['install puppetserver gem hiera-eyaml'],
+    ]
 
     # figure out what files get installed where so that we can tell if installation
     # succeeded

--- a/manifests/eyaml.pp
+++ b/manifests/eyaml.pp
@@ -27,6 +27,8 @@ class hiera::eyaml (
   }
 
   if $provider == 'pe_puppetserver_gem' {
+    $hiera_package_dep = Exec['install pe_gem']
+
     # The puppetserver gem wouldn't install the commandline util, so we do
     # that here
     #XXX Pre-puppet 4.0.0 version (PUP-1073)
@@ -48,6 +50,7 @@ class hiera::eyaml (
     #  source   => $gem_source,
     #}
   } else {
+    $hiera_package_dep = Package['hiera-eyaml']
     package { 'hiera-eyaml':
       ensure   => $package_ensure,
       provider => $provider,
@@ -71,7 +74,7 @@ class hiera::eyaml (
       command => 'eyaml createkeys',
       path    => $cmdpath,
       creates => "${confdir}/keys/private_key.pkcs7.pem",
-      require => [ Package['hiera-eyaml'], File["${confdir}/keys"] ]
+      require => [ $hiera_package_dep, File["${confdir}/keys"] ]
     }
 
     file { "${confdir}/keys/private_key.pkcs7.pem":

--- a/manifests/eyaml.pp
+++ b/manifests/eyaml.pp
@@ -45,11 +45,13 @@ class hiera::eyaml (
     # figure out what files get installed where so that we can tell if installation
     # succeeded
     if $pe_server_version {
-      $vendored_gem_creates = '/opt/puppet/bin/eyaml'
-      $puppetserver_gem_creates = '/var/opt/lib/pe-puppet-server/jruby-gems/bin/eyaml'
-    } else {
-      $vendored_gem_creates = '/opt/puppetlabs/puppet/bin/eyaml'
+      # PE 2015
+      $vendored_gem_creates     = '/opt/puppetlabs/puppet/bin/eyaml'
       $puppetserver_gem_creates = '/opt/puppetlabs/server/data/puppetserver/jruby-gems/bin/eyaml'
+    } else {
+      # PE 3.x
+      $vendored_gem_creates     = '/opt/puppet/bin/eyaml'
+      $puppetserver_gem_creates = '/var/opt/lib/pe-puppet-server/jruby-gems/bin/eyaml'
     }
 
     # The puppetserver gem wouldn't install the commandline util, so we do

--- a/manifests/eyaml.pp
+++ b/manifests/eyaml.pp
@@ -11,7 +11,7 @@
 # Copyright (C) 2014 Terri Haber, unless otherwise noted.
 #
 class hiera::eyaml (
-  $provider      = $hiera::params::provider,
+  $provider      = $hiera::provider,
   $owner         = $hiera::owner,
   $group         = $hiera::group,
   $cmdpath       = $hiera::cmdpath,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,6 +57,7 @@ class hiera (
   $eyaml_version   = undef,
   $merge_behavior  = undef,
   $extra_config    = '',
+  $provider        = $hiera::params::provider,
 ) inherits hiera::params {
   File {
     owner => $owner,


### PR DESCRIPTION
PR fixes:
* Gem installation on PE 2015.2 (use provider `pe_puppetserver_gem`)
* Add a `provider` parameter to `init.pp` and rework in `eyaml.pp`
* Install the gem once with vendored ruby and again for puppetserver if PE detected (uses execs)
* Fix event dependencies caused by above
* Only use a package resource to install `hiera-eyaml` on OSS puppet