### PR TITLE
Add default compatibility with PE 2015.2.0

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,7 +22,6 @@ class hiera::params {
     $confdir    = '/etc/puppetlabs/puppet'
     $cmdpath    = ['/opt/puppet/bin', '/usr/bin', '/usr/local/bin']
 
-
     if versioncmp($::pe_version, '3.7.0') >= 0 {
       $provider = 'pe_puppetserver_gem'
     }
@@ -41,9 +40,15 @@ class hiera::params {
       $confdir  = '/etc/puppet'
       $cmdpath  = ['/usr/bin', '/usr/local/bin']
     }
+    if versioncmp($::pe_server_version, '2015.2.0') >= 0 {
+      $owner    = 'pe-puppet'
+      $group    = 'pe-puppet'
+    }
+    else {
+      $owner    = 'puppet'
+      $group    = 'puppet'
+    }
     $hiera_yaml = "${confdir}/hiera.yaml"
     $datadir    = "${confdir}/hieradata"
-    $owner      = 'puppet'
-    $group      = 'puppet'
   }
 }


### PR DESCRIPTION
The default owner/group in Puppet Enterprise 2015.2.0 still need to be pe-puppet, because puppet is not a valid user/group. This commit adds logic to check the $pe_server_version fact to determine whether the server is PE or opensource, and set the default owner/group accordingly.