### PR TITLE
Clean up style of hiera.yaml.erb template

### DIFF
--- a/templates/hiera.yaml.erb
+++ b/templates/hiera.yaml.erb
@@ -5,15 +5,17 @@
   @backends.unshift('eyaml')
   @backends = @backends.uniq
 end -%>
-<%= @backends.to_yaml.split("\n")[1..-1].join("\n") %>
+<%= @backends.to_yaml.split("\n")[1..-1].map{|e| "  #{e}"}.join("\n") %>
+
 :logger: <%= @logger %>
+
 :hierarchy:
-<%= @hierarchy.to_yaml.split("\n")[1..-1].join("\n") %>
+<%= @hierarchy.to_yaml.split("\n")[1..-1].map{|e| "  #{e}"}.join("\n") %>
 
 :yaml:
-   :datadir: <%= @datadir %>
-
+  :datadir: <%= @datadir %>
 <% if @eyaml -%>
+
 :eyaml:
    :datadir: <%= @eyaml_real_datadir %>
 <% if @eyaml_extension -%>
@@ -22,9 +24,11 @@ end -%>
    :pkcs7_private_key: <%= @confdir %>/keys/private_key.pkcs7.pem
    :pkcs7_public_key:  <%= @confdir %>/keys/public_key.pkcs7.pem
 <% end -%>
-
 <% if @merge_behavior -%>
+
 :merge_behavior: <%= @merge_behavior -%>
 <% end -%>
+<% if @extra_config && !@extra_config.empty? -%>
 
 <%= @extra_config %>
+<% end -%>


### PR DESCRIPTION
This is a style commit intended to clean up the YAML output of the
hiera.yaml.erb template for easier presentation.

  - Eliminates redundant newlines. If a parameter is undef or empty,
    there need not be a blank newline holding its place. Style changes
    to put formatting newlines into the conditional that places the
    parameter, so that they are not included if the parameter is not used.

  - Consistent indenting. Use two-space indents, use indents in
    hierarchy array.

  - Consistent spacing. Use a space between all keys or no keys. This
    commit adds a space between all keys.

Example:

````puppet
class { 'hiera':
  datadir_manage => false,
  notify         => Service['pe-puppetserver'],
  hierarchy      => [
    'nodes/%{clientcert}',
    'environment/%{environment}',
    'datacenter/%{datacenter}',
    'virtual/%{virtual}',
    'common',
  ],
}
````

Before this commit, generated:

````
# managed by puppet
---
:backends:
- yaml
:logger: console
:hierarchy:
- nodes/%{clientcert}
- environment/%{environment}
- datacenter/%{datacenter}
- virtual/%{virtual}
- common

:yaml:
   :datadir: /etc/puppetlabs/code/hieradata




````

After this commit, generates:

````
# managed by puppet
---
:backends:
  - yaml

:logger: console

:hierarchy:
  - nodes/%{clientcert}
  - environment/%{environment}
  - datacenter/%{datacenter}
  - virtual/%{virtual}
  - common

:yaml:
  :datadir: /etc/puppetlabs/code/hieradata
````