### PR TITLE
Fixing 2015.2 handling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,11 @@ group :development, :test do
   gem 'pry',                     :require => false
 end
 
+group :system_tests do
+  gem 'beaker-rspec',                 :require => false
+  gem 'beaker-puppet_install_helper', :require => false
+end
+
 if facterversion = ENV['FACTER_GEM_VERSION']
   gem 'facter', facterversion, :require => false
 else

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,14 +25,12 @@ class hiera::params {
     if versioncmp($::pe_version, '3.7.0') >= 0 {
       $provider       = 'pe_puppetserver_gem'
       $master_service = 'pe-puppetserver'
-    }
-    else {
+    } else {
       $provider       = 'pe_gem'
       $master_service = 'pe-httpd'
     }
-  }
-  else {
-    if is_function_available('pe_compiling_server_version') {
+  } else {
+    if $::pe_server_version {
       $master_service = 'pe-puppetserver'
     } else {
       $master_service = 'puppetmaster'
@@ -47,11 +45,10 @@ class hiera::params {
       $confdir  = '/etc/puppet'
       $cmdpath  = ['/usr/bin', '/usr/local/bin']
     }
-    if versioncmp($::pe_server_version, '2015.2.0') >= 0 {
+    if $::pe_server_version {
       $owner    = 'pe-puppet'
       $group    = 'pe-puppet'
-    }
-    else {
+    } else {
       $owner    = 'puppet'
       $group    = 'puppet'
     }

--- a/spec/acceptance/hiera_spec.rb
+++ b/spec/acceptance/hiera_spec.rb
@@ -1,0 +1,90 @@
+require 'spec_helper_acceptance'
+
+describe 'hiera' do
+  version = on(master, puppet('--version')).stdout
+  case version
+  when /Puppet Enterprise 3/
+    confdir = '/etc/puppetlabs/puppet'
+    manifestsdir = "#{confdir}/manifests"
+  when /^3/
+    confdir = '/etc/puppet'
+    manifestsdir = "#{confdir}/manifests"
+  when /^4/
+    confdir = '/etc/puppetlabs/code'
+    manifestsdir = "#{confdir}/environments/production/manifests"
+  else
+    fail "Unknown puppet version #{version}"
+  end
+  hierayaml = "#{confdir}/hiera.yaml"
+  datadir = "#{confdir}/hieradata"
+  sitepp = File.join(manifestsdir, 'site.pp')
+
+  describe 'puppet apply' do
+    it 'creates a hiera.yaml' do
+      pp = <<-EOS
+      class { 'hiera':
+        eyaml     => true,
+        hierarchy => [
+          '%{environment}/%{calling_class}',
+          '%{environment}',
+          'common',
+        ],
+      }
+      EOS
+      apply_manifest_on(master, pp, :catch_failures => true)
+      apply_manifest_on(master, pp, :catch_changes => true)
+    end
+  end
+  describe file(hierayaml), :node => master do
+    its(:content) do should eq(<<-EOS
+# managed by puppet
+---
+:backends:
+  - eyaml
+  - yaml
+
+:logger: console
+
+:hierarchy:
+  - "%{environment}/%{calling_class}"
+  - "%{environment}"
+  - common
+
+:yaml:
+  :datadir: #{datadir}
+
+:eyaml:
+  :datadir: #{datadir}
+  :pkcs7_private_key: #{confdir}/keys/private_key.pkcs7.pem
+  :pkcs7_public_key:  #{confdir}/keys/public_key.pkcs7.pem
+EOS
+      )
+    end
+  end
+  describe 'querying hiera' do
+    let(:pp) do
+      <<-EOS
+      class myclass {
+        notify { hiera('myclass::value'): }
+      }
+      include myclass
+      EOS
+    end
+    before :all do
+      on master, "mkdir -p #{datadir}/production"
+      on master, "echo myclass::value: 'found output' > #{datadir}/production/myclass.eyaml"
+    end
+    it 'finds it on the command line' do
+      expect(on(master, 'hiera myclass::value environment=production calling_class=myclass').stdout.strip).to eq('found output')
+    end
+    it 'finds it in puppet apply' do
+      expect(apply_manifest_on(master, pp, :catch_failures => true).stdout.strip).to match(%r{found output})
+    end
+    it 'finds it in puppet agent', :if => (master.is_pe? || master[:roles].include?('aio')) do
+      on master, "mkdir -p #{manifestsdir}"
+      create_remote_file(master, sitepp, pp)
+      sleep(5)
+      expect(on(master, puppet('agent', '-t', '--server', '$(hostname -f)'), :acceptable_exit_codes => [0,2]).stdout.strip).to match(%r{found output})
+    end
+  end
+end

--- a/spec/acceptance/nodesets/pe-redhat-7-vcloud.yml
+++ b/spec/acceptance/nodesets/pe-redhat-7-vcloud.yml
@@ -1,0 +1,18 @@
+HOSTS:
+  'redhat-7-vcloud':
+    roles:
+      - master
+      - dashboard
+      - database
+      - agent
+    platform: el-7-x86_64
+    hypervisor: vcloud
+    template: redhat-7-x86_64
+CONFIG:
+  type: pe
+  ssh:
+    keys: "~/.ssh/id_rsa-acceptance"
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/

--- a/spec/acceptance/nodesets/pe-ubuntu-1404-vcloud.yml
+++ b/spec/acceptance/nodesets/pe-ubuntu-1404-vcloud.yml
@@ -1,0 +1,18 @@
+HOSTS:
+  'ubuntu-1404-vcloud':
+    roles:
+      - master
+      - dashboard
+      - database
+      - agent
+    platform: ubuntu-1404-x86_64
+    template: ubuntu-1404-x86_64
+    hypervisor: vcloud
+CONFIG:
+  type: pe
+  ssh:
+    keys: "~/.ssh/id_rsa-acceptance"
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/

--- a/spec/acceptance/nodesets/redhat-7-vcloud.yml
+++ b/spec/acceptance/nodesets/redhat-7-vcloud.yml
@@ -1,0 +1,15 @@
+HOSTS:
+  'redhat-7-vcloud':
+    roles:
+      - master
+    platform: el-7-x86_64
+    hypervisor: vcloud
+    template: redhat-7-x86_64
+CONFIG:
+  type: foss
+  ssh:
+    keys: "~/.ssh/id_rsa-acceptance"
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/

--- a/spec/acceptance/nodesets/ubuntu-1404-vcloud.yml
+++ b/spec/acceptance/nodesets/ubuntu-1404-vcloud.yml
@@ -1,0 +1,15 @@
+HOSTS:
+  'ubuntu-1404-vcloud':
+    roles:
+      - master
+    platform: ubuntu-1404-x86_64
+    template: ubuntu-1404-x86_64
+    hypervisor: vcloud
+CONFIG:
+  type: foss
+  ssh:
+    keys: "~/.ssh/id_rsa-acceptance"
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/

--- a/spec/classes/hiera_spec.rb
+++ b/spec/classes/hiera_spec.rb
@@ -1,14 +1,79 @@
 require 'spec_helper'
 
 describe 'hiera' do
-  let(:facts) do
-    { :puppet_version => '3.7.1', }
+  context "foss" do
+    context "puppet 3" do
+      let(:facts) do
+        { :puppetversion => '3.7.1', }
+      end
+      describe 'default params' do
+        it { should compile.with_all_deps }
+      end
+      describe 'eyaml param' do
+        let(:params) { { :eyaml => true }}
+        it { should contain_class("hiera::eyaml") }
+      end
+    end
+    context "puppet 4" do
+      let(:facts) do
+        { :puppetversion => '4.2.0', }
+      end
+      describe 'default params' do
+        it { should compile.with_all_deps }
+      end
+      describe 'eyaml param' do
+        let(:params) { { :eyaml => true }}
+        it { should contain_class("hiera::eyaml") }
+      end
+    end
   end
-  describe 'default params' do
-    it { should compile.with_all_deps }
-  end
-  describe 'eyaml param' do
-    let(:params) { { :eyaml => true }}
-    it { should contain_class("hiera::eyaml") }
+  context "pe" do
+    context "puppet 3" do
+      let(:facts) do
+        {
+          :puppetversion => 'Puppet Enterprise 3.8.0',
+          :is_pe         => true,
+          :pe_version    => '3.8.0',
+        }
+      end
+      describe 'default params' do
+        it { should compile.with_all_deps }
+      end
+      describe 'eyaml param' do
+        let(:params) { { :eyaml => true }}
+        it { should contain_class("hiera::eyaml") }
+      end
+    end
+    context "puppet 4" do
+      let(:facts) do
+        {
+          :puppetversion => 'Puppet Enterprise 4.0.0',
+          :is_pe         => true,
+          :pe_version    => '4.0.0',
+        }
+      end
+      describe 'default params' do
+        it { should compile.with_all_deps }
+      end
+      describe 'eyaml param' do
+        let(:params) { { :eyaml => true }}
+        it { should contain_class("hiera::eyaml") }
+      end
+    end
+    context "puppet 2015.2" do
+      let(:facts) do
+        {
+          :puppetversion     => '4.2.1',
+          :pe_server_version => '2015.2.1',
+        }
+      end
+      describe 'default params' do
+        it { should compile.with_all_deps }
+      end
+      describe 'eyaml param' do
+        let(:params) { { :eyaml => true }}
+        it { should contain_class("hiera::eyaml") }
+      end
+    end
   end
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,21 @@
+require 'beaker-rspec'
+require 'beaker/puppet_install_helper'
+
+run_puppet_install_helper
+
+RSpec.configure do |c|
+  # Project root
+  proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+
+  # Readable test descriptions
+  c.formatter = :documentation
+
+  # Configure all nodes in nodeset
+  c.before :suite do
+    # Install module and dependencies
+    puppet_module_install(:source => proj_root, :module_name => 'hiera')
+    hosts.each do |host|
+      on host, puppet('module','install','puppetlabs-stdlib'), { :acceptable_exit_codes => [0,1] }
+    end
+  end
+end

--- a/templates/hiera.yaml.erb
+++ b/templates/hiera.yaml.erb
@@ -5,24 +5,24 @@
   @backends.unshift('eyaml')
   @backends = @backends.uniq
 end -%>
-<%= @backends.to_yaml.split("\n")[1..-1].map{|e| "  #{e}"}.join("\n") %>
+<%= @backends.to_yaml.split("\n")[1..-1].map{|e| "  #{e.strip}"}.join("\n") %>
 
 :logger: <%= @logger %>
 
 :hierarchy:
-<%= @hierarchy.to_yaml.split("\n")[1..-1].map{|e| "  #{e}"}.join("\n") %>
+<%= @hierarchy.to_yaml.split("\n")[1..-1].map{|e| "  #{e.strip}"}.join("\n") %>
 
 :yaml:
   :datadir: <%= @datadir %>
 <% if @eyaml -%>
 
 :eyaml:
-   :datadir: <%= @eyaml_real_datadir %>
+  :datadir: <%= @eyaml_real_datadir %>
 <% if @eyaml_extension -%>
-   :extension: <%= @eyaml_extension %>
+  :extension: <%= @eyaml_extension %>
 <% end -%>
-   :pkcs7_private_key: <%= @confdir %>/keys/private_key.pkcs7.pem
-   :pkcs7_public_key:  <%= @confdir %>/keys/public_key.pkcs7.pem
+  :pkcs7_private_key: <%= @confdir %>/keys/private_key.pkcs7.pem
+  :pkcs7_public_key:  <%= @confdir %>/keys/public_key.pkcs7.pem
 <% end -%>
 <% if @merge_behavior -%>
 


### PR DESCRIPTION
This PE stuff is confusing.

This should fix the hiera-eyaml installation on PE 2015.2. It also fixes
a bug with versioncmp() trying to compare $::pe_server_version when it
is undef to determine if it's on PE or FOSS puppetserver.

It also updates the formatting of hiera.yaml to be a bit more
consistent across puppet versions (thanks zaml for being not like yaml).

This adds beaker tests that should work on foss puppet 3, PE 3, and
PE 2015.2+puppet-agent packaging.

Rework of #77