### PR TITLE
Added option to switch on/off the creation of the /etc/hiera.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ The following parameters are available for the hiera class:
   Default:
     * `'/etc/puppet/hiera.yaml'` for Puppet Open Source
     * `'/etc/puppetlabs/puppet/hiera.yaml'` for Puppet Enterprise
+* `create_symlink`
+  Whether to create the symlink `/etc/hiera.yaml`
+  Default: true
 * `datadir`  
   The path to the directory where hiera will look for databases.  
   Default:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,6 +42,7 @@ class hiera (
   $hierarchy       = [],
   $backends        = ['yaml'],
   $hiera_yaml      = $hiera::params::hiera_yaml,
+  $create_symlink  = true,
   $datadir         = $hiera::params::datadir,
   $datadir_manage  = true,
   $owner           = $hiera::params::owner,
@@ -97,10 +98,13 @@ class hiera (
     content => template('hiera/hiera.yaml.erb'),
   }
   # Symlink for hiera command line tool
-  file { '/etc/hiera.yaml':
-    ensure => symlink,
-    target => $hiera_yaml,
+  if $create_symlink {
+    file { '/etc/hiera.yaml':
+      ensure => symlink,
+      target => $hiera_yaml,
+    }
   }
+
   # Restart master service
   Service <| title == $master_service |> {
     subscribe +> File[$hiera_yaml],


### PR DESCRIPTION
Recently I have used this module in deploying a development environment as a non-root user (puppet apply) for local users in their homedirectory using ~/.puppet/hiera.yaml as a config file - this worked fine apart from the fact that the module always wants to create /etc/hiera.yaml.

This PR makes it possible to turn this feature off, default is true so there is no breaking change here.

