### PR TITLE
Add provider to class parameters

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,6 +47,7 @@ class hiera (
   $datadir_manage  = true,
   $owner           = $hiera::params::owner,
   $group           = $hiera::params::group,
+  $provider        = $hiera::params::provider,
   $eyaml           = false,
   $eyaml_datadir   = undef,
   $eyaml_extension = undef,


### PR DESCRIPTION
I needed to override the provider when I wanted to include hiera-eyaml because I'm using puppetserver.