### PR TITLE
Quoted facter variables for versioncmp function

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,7 +22,7 @@ class hiera::params {
     $confdir    = '/etc/puppetlabs/puppet'
     $cmdpath    = ['/opt/puppet/bin', '/usr/bin', '/usr/local/bin']
 
-    if versioncmp($::pe_version, '3.7.0') >= 0 {
+    if versioncmp("$::pe_version", '3.7.0') >= 0 {
       $provider       = 'pe_puppetserver_gem'
       $master_service = 'pe-puppetserver'
     } else {
@@ -35,7 +35,7 @@ class hiera::params {
     } else {
       $master_service = 'puppetmaster'
     }
-    if versioncmp($::puppetversion, '4.0.0') >= 0 {
+    if versioncmp("$::puppetversion", '4.0.0') >= 0 {
       # Configure for AIO packaging.
       $provider = 'puppet_gem'
       $confdir  = '/etc/puppetlabs/code'


### PR DESCRIPTION
I'm working on a new installation of PE 2015.3 and discovered that versioncmp was throwing an error:

Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, 'versioncmp' parameter 'a' expects a String value, got Undef at /etc/puppetlabs/code/environments/production/modules/hiera/manifests/params.pp:43:8

Quoting the facter variables in params.pp solved the problem, although I'm not sure why facter wasn't returning a string value in the first place.