### PR TITLE
fix eyaml keys location

### DIFF
--- a/templates/hiera.yaml.erb
+++ b/templates/hiera.yaml.erb
@@ -21,8 +21,8 @@ end -%>
 <% if @eyaml_extension -%>
   :extension: <%= @eyaml_extension %>
 <% end -%>
-  :pkcs7_private_key: <%= @confdir %>/keys/private_key.pkcs7.pem
-  :pkcs7_public_key:  <%= @confdir %>/keys/public_key.pkcs7.pem
+  :pkcs7_private_key: <%= scope.lookupvar('hiera::eyaml::confdir') %>/keys/private_key.pkcs7.pem
+  :pkcs7_public_key:  <%= scope.lookupvar('hiera::eyaml::confdir') %>/keys/public_key.pkcs7.pem
 <% end -%>
 <% if @merge_behavior -%>
 


### PR DESCRIPTION
Prior to this commit module has allowed to configure key eyaml key location in hiera::eyaml class,
but ignored it in the template