### PR TITLE
Remove custom eyaml package from test

### DIFF
--- a/spec/acceptance/hiera_spec.rb
+++ b/spec/acceptance/hiera_spec.rb
@@ -28,7 +28,6 @@ describe 'hiera' do
       pp = <<-EOS
       class { 'hiera':
         eyaml              => true,
-        eyaml_name         => 'custom-eyaml',
         merge_behavior     => 'deep',
         puppet_conf_manage => true,
         hierarchy          => [


### PR DESCRIPTION
This package doesn't actually exist, so causes tests to fail.